### PR TITLE
Dev.strello

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+ILSAstats.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Calculates ILSA statistics using replicate weights and plausible va
 Encoding: UTF-8
 LazyData: true
 LazyDataCompression: xz
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.2.2
 Imports: 
 Suggests: wCorr, lme4
 Depends: R (>= 3.5.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ILSAstats
 Type: Package
 Title: Statistics for International Large-Scale Assessments (ILSA) 
-Version: 0.3.101
+Version: 0.3.102
 Authors@R: c(person(given = "Andrés",
                     family = "Christiansen",
                     role = c("aut","cre"),
@@ -16,7 +16,7 @@ Description: Calculates ILSA statistics using replicate weights and plausible va
 Encoding: UTF-8
 LazyData: true
 LazyDataCompression: xz
-RoxygenNote: 7.3.2.2
+RoxygenNote: 7.3.2
 Imports: 
 Suggests: wCorr, lme4
 Depends: R (>= 3.5.0)

--- a/R/repmean.R
+++ b/R/repmean.R
@@ -232,10 +232,10 @@ repmean <- function(x, PV = FALSE, setup = NULL, repwt, wt, df,
 
 
     out <- outp[[1]]
-    class(out) <- c(class(out),"repmean")
+    class(out) <- c("repmean", class(out))
 
     if(!"variable"%in%colnames(out)){
-      class(out) <- c(class(out),"repmean.single")
+      class(out) <- c("repmean.single", class(out))
     }
 
     return(out)
@@ -417,15 +417,15 @@ repmean <- function(x, PV = FALSE, setup = NULL, repwt, wt, df,
 
   out <- lapply(out,function(i){
     outi <- i
-    class(outi) <- c(class(outi),"repmean")
+    class(outi) <- c("repmean", class(outi))
     if(!"variable"%in%colnames(outi)){
-      class(outi) <- c(class(outi),"repmean.single")
+      class(outi) <- c("repmean.single", class(outi))
     }
     outi
 
   })
 
-  class(out) <- c(class(out),"repmean","repmean.list")
+  class(out) <- c("repmean","repmean.list", class(out))
 
 
 
@@ -625,10 +625,10 @@ repmean <- function(x, PV = FALSE, setup = NULL, repwt, wt, df,
 
 
     out <- outp[[1]]
-    class(out) <- c(class(out),"repmean")
+    class(out) <- c("repmean", class(out))
 
     if(!"variable"%in%colnames(out)){
-      class(out) <- c(class(out),"repmean.single")
+      class(out) <- c("repmean.single", class(out))
     }
 
     return(out)
@@ -810,15 +810,15 @@ repmean <- function(x, PV = FALSE, setup = NULL, repwt, wt, df,
 
   out <- lapply(out,function(i){
     outi <- i
-    class(outi) <- c(class(outi),"repmean")
+    class(outi) <- c("repmean", class(outi))
     if(!"variable"%in%colnames(outi)){
-      class(outi) <- c(class(outi),"repmean.single")
+      class(outi) <- c("repmean.single",class(outi))
     }
     outi
 
   })
 
-  class(out) <- c(class(out),"repmean","repmean.list")
+  class(out) <- c("repmean","repmean.list", class(out))
 
 
 

--- a/R/repmeandif.R
+++ b/R/repmeandif.R
@@ -128,7 +128,7 @@ repmeandif <- function(x){
 
   out <- rbind.data.frame(mcom,mdiftot)
   rownames(out) <- NULL
-  class(out) <- c(class(out),"repmeandif")
+  class(out) <- c("repmeandif", class(out))
   out
 
 


### PR DESCRIPTION
Changed the order of the class attributes returned in ILSAstats objects. This was giving problems with other packages (e.g., dplyr) that were not recognizing that the objects were data.frame too (it needs to have data.frame as the latest class)